### PR TITLE
Update a lead sentence in quickstart-install-connect-docker.md

### DIFF
--- a/docs/linux/quickstart-install-connect-docker.md
+++ b/docs/linux/quickstart-install-connect-docker.md
@@ -51,7 +51,7 @@ ms.lasthandoff: 12/04/2017
    docker pull microsoft/mssql-server-linux:2017-latest
    ```
 
-   前のコマンドは、最新の SQL Server 2017 コンテナー イメージを取得します。特定のイメージを取得するには、コロンとタグ名を追加します (たとえば、 `microsoft/mssql-server-linux:2017-GA`)。 利用可能なすべてのイメージを表示するには [mssql-server-linux Docker hub ページ](https://hub.docker.com/r/microsoft/mssql-server-linux/tags/) を参照してください。
+   前のコマンドは、最新の SQL Server 2017 コンテナー イメージをプルします。特定のイメージをプルするには、コロンとタグ名を追加します (たとえば、 `microsoft/mssql-server-linux:2017-GA`)。 利用可能なすべてのイメージを表示するには [mssql-server-linux Docker hub ページ](https://hub.docker.com/r/microsoft/mssql-server-linux/tags/) を参照してください。
 
 1. Docker でコンテナー イメージを実行するには、bash シェル (Linux/macOS) または管理者特権の PowerShell コマンド プロンプトから次のコマンドを使用できます。
 
@@ -68,15 +68,15 @@ ms.lasthandoff: 12/04/2017
    ```
 
    > [!NOTE]
-   > 既定では、これは SQL Server 2017 の Developer エディションのコンテナーを作成します。コンテナーで実稼働のエディションを実行するためのプロセスは若干異なります。さらに詳しい情報は [実稼働環境のコンテナー イメージを実行する](sql-server-linux-configure-docker.md#production) を参照してください。
+   > 既定では、これは SQL Server 2017 の Developer エディションのコンテナーを作成します。コンテナーで実稼働のエディションを実行するためのプロセスは若干異なります。詳細については「[実稼働環境のコンテナー イメージを実行する](sql-server-linux-configure-docker.md#production)」を参照してください。
 
-   次の表は、以前の `docker run` におけるパラメーターの例を説明を示しています。
+   次の表では、前述の `docker run` の例におけるパラメーターを説明しています。
 
    | パラメーター | 説明 |
    |-----|-----|
    | **e ' ACCEPT_EULA = Y'** | **ACCEPT_EULA** 変数に [使用許諾契約書](http://go.microsoft.com/fwlink/?LinkId=746388) の同意を確認するための任意の値を設定します。 SQL Server イメージの設定が必要です。 |
-   | **e ' MSSQL_SA_PASSWORD =\<YourStrong!Passw0rd\>'** | 8 文字以上で、 [SQL Server のパスワード要件](../relational-databases/security/password-policy.md) を満たす強力なパスワードを指定します。 SQL Server イメージの設定が必要です。 |
-   | **-p 1401:1433** | ホスト環境の TCP ポート (最初の値) を コンテナーの TCP ポート (2 番目の値) に割り当てます。この例では、 SQL Server はコンテナーの TCP 1433 でリッスンし、これはホストのポート 1401 で受け付けられます。 |
+   | **e ' MSSQL_SA_PASSWORD =\<YourStrong!Passw0rd\>'** | 8 文字以上で、 [SQL Server のパスワード要件](../relational-databases/security/password-policy.md) を満たす強力なパスワードを指定します。 SQL Server イメージに必須の設定です。 |
+   | **-p 1401:1433** | ホスト環境の TCP ポート (最初の値) を コンテナーの TCP ポート (2 番目の値) にマップします。この例では、 SQL Server はコンテナーの TCP 1433 でリッスンし、これがホストのポート 1401 に公開されます。 |
    | **--name sql1** | ランダムに生成されたものではなく、コンテナーのカスタム名を指定します。 2 つ以上のコンテナーを実行する場合、同じ名前を再利用することはできません。 |
    | **microsoft/mssql-server-linux:2017-latest** | SQL Server 2017 Linux コンテナー イメージ。 |
 

--- a/docs/linux/quickstart-install-connect-docker.md
+++ b/docs/linux/quickstart-install-connect-docker.md
@@ -39,7 +39,7 @@ ms.lasthandoff: 12/04/2017
 - 2 GB の RAM の最小値
 - [Linux 上の SQL Server のシステム要件](sql-server-linux-setup.md#system)です。
 
-## <a name="pull-and-run-the-container-image"></a>プルし、コンテナー イメージを実行
+## <a name="pull-and-run-the-container-image"></a>コンテナー イメージのプルと実行
 
 1. SQL Server 2017 Linux コンテナー イメージを Docker Hub からプルします。
 
@@ -51,9 +51,9 @@ ms.lasthandoff: 12/04/2017
    docker pull microsoft/mssql-server-linux:2017-latest
    ```
 
-   前のコマンドは、最新の SQL Server 2017 コンテナー イメージを取得します。 コロンとタグ名を追加する場合は、特定のイメージを取得するには、(たとえば、 `microsoft/mssql-server-linux:2017-GA`)。 すべての利用可能なイメージを表示するには、次を参照してください。 [mssql サーバー linux Docker ハブ ページ](https://hub.docker.com/r/microsoft/mssql-server-linux/tags/)です。
+   前のコマンドは、最新の SQL Server 2017 コンテナー イメージを取得します。特定のイメージを取得するには、コロンとタグ名を追加します (たとえば、 `microsoft/mssql-server-linux:2017-GA`)。 利用可能なすべてのイメージを表示するには [mssql-server-linux Docker hub ページ](https://hub.docker.com/r/microsoft/mssql-server-linux/tags/) を参照してください。
 
-1. Docker によってコンテナー イメージを実行するには、bash シェル (Linux/macOS) または管理者特権の PowerShell コマンド プロンプトから次のコマンドを使用できます。
+1. Docker でコンテナー イメージを実行するには、bash シェル (Linux/macOS) または管理者特権の PowerShell コマンド プロンプトから次のコマンドを使用できます。
 
    ```bash
    sudo docker run -e 'ACCEPT_EULA=Y' -e 'MSSQL_SA_PASSWORD=<YourStrong!Passw0rd>' \
@@ -68,17 +68,17 @@ ms.lasthandoff: 12/04/2017
    ```
 
    > [!NOTE]
-   > 既定では、これは、コンテナーを作成 2017 年 1 SQL Server の Developer edition を使用します。 コンテナーで実稼働のエディションを実行するためのプロセスは若干異なります。 詳細については、次を参照してください。[実稼働環境にコンテナー イメージを実行](sql-server-linux-configure-docker.md#production)です。
+   > 既定では、これは SQL Server 2017 の Developer エディションのコンテナーを作成します。コンテナーで実稼働のエディションを実行するためのプロセスは若干異なります。さらに詳しい情報は [実稼働環境のコンテナー イメージを実行する](sql-server-linux-configure-docker.md#production) を参照してください。
 
-   次の表は、前に、パラメーターの説明を示します`docker run`例。
+   次の表は、以前の `docker run` におけるパラメーターの例を説明を示しています。
 
-   | パラメーター | Description |
+   | パラメーター | 説明 |
    |-----|-----|
-   | **e ' ACCEPT_EULA = Y'** |  設定、 **ACCEPT_EULA**変数への同意を確認する任意の値を[使用許諾契約書](http://go.microsoft.com/fwlink/?LinkId=746388)です。 SQL Server イメージの設定が必要です。 |
-   | **e ' MSSQL_SA_PASSWORD =\<YourStrong!Passw0rd\>'** | 8 文字以上には、満たす独自の強力なパスワードを指定、 [SQL Server のパスワード要件](../relational-databases/security/password-policy.md)です。 SQL Server イメージの設定が必要です。 |
-   | **-p 1401:1433** | ホスト環境での TCP ポートにマップ (先頭の値)、コンテナーの TCP ポートと (2 番目の値)。 この例では SQL Server がコンテナー内の TCP 1433 でリッスンしていると、ホスト上の 1401 ポートにこの公開されます。 |
-   | **-名前 sql1** | ランダムに生成されたものではなく、コンテナーのカスタム名を指定します。 1 つ以上のコンテナーを実行すると場合に、この同じ名前を再利用することはできません。 |
-   | **microsoft/mssql-サーバー-linux:2017-最新** | SQL Server 2017 Linux コンテナー イメージ。 |
+   | **e ' ACCEPT_EULA = Y'** | **ACCEPT_EULA** 変数に [使用許諾契約書](http://go.microsoft.com/fwlink/?LinkId=746388) の同意を確認するための任意の値を設定します。 SQL Server イメージの設定が必要です。 |
+   | **e ' MSSQL_SA_PASSWORD =\<YourStrong!Passw0rd\>'** | 8 文字以上で、 [SQL Server のパスワード要件](../relational-databases/security/password-policy.md) を満たす強力なパスワードを指定します。 SQL Server イメージの設定が必要です。 |
+   | **-p 1401:1433** | ホスト環境の TCP ポート (最初の値) を コンテナーの TCP ポート (2 番目の値) に割り当てます。この例では、 SQL Server はコンテナーの TCP 1433 でリッスンし、これはホストのポート 1401 で受け付けられます。 |
+   | **--name sql1** | ランダムに生成されたものではなく、コンテナーのカスタム名を指定します。 2 つ以上のコンテナーを実行する場合、同じ名前を再利用することはできません。 |
+   | **microsoft/mssql-server-linux:2017-latest** | SQL Server 2017 Linux コンテナー イメージ。 |
 
 1. 表示するには、Docker コンテナーを使用して、`docker ps`コマンド。
 


### PR DESCRIPTION
I found a bit unnatural sentence in Japanese language and wrong translations, and I would like to fix it. This proposal is supposed to be addressed as a `Linguistic Suggestion` from my point of view. It would be appreciated if you would check this proposal. Please let me know if you have any concerns.

This request is in regard to:

- [Run the SQL Server 2017 container image with Docker](https://docs.microsoft.com/en-us/sql/linux/quickstart-install-connect-docker)
- [Docker を使用した SQL Server 2017 コンテナー イメージを実行します。](https://docs.microsoft.com/ja-jp/sql/linux/quickstart-install-connect-docker)

Best regards,