### PR TITLE
Names should not be translated

### DIFF
--- a/docs/ado/guide/appendixes/microsoft-ole-db-provider-for-microsoft-indexing-service.md
+++ b/docs/ado/guide/appendixes/microsoft-ole-db-provider-for-microsoft-indexing-service.md
@@ -1,5 +1,5 @@
 ---
-title: Microsoft OLE DB Provider for Microsoft インテックス サービス |Microsoft ドキュメント
+title: Microsoft OLE DB Provider for Microsoft インデックス サービス |Microsoft ドキュメント
 ms.prod: sql
 ms.prod_service: connectivity
 ms.technology: connectivity
@@ -26,7 +26,7 @@ ms.lasthandoff: 06/11/2018
 ms.locfileid: "35271311"
 ---
 # <a name="microsoft-ole-db-provider-for-microsoft-indexing-service-overview"></a>Microsoft OLE DB Provider for Microsoft インデックス作成サービスの概要
-Microsoft OLE DB Provider for Microsoft インテックス サービスは、ファイル システムと Microsoft Indexing Service でインデックス付けされた Web データにプログラムでの読み取り専用アクセスを提供します。 ADO アプリケーションでは、コンテンツとファイルのプロパティ情報を取得する SQL クエリを発行できます。
+Microsoft OLE DB Provider for Microsoft インデックス サービスは、ファイル システムと Microsoft Indexing Service でインデックス付けされた Web データにプログラムでの読み取り専用アクセスを提供します。 ADO アプリケーションでは、コンテンツとファイルのプロパティ情報を取得する SQL クエリを発行できます。
 
  プロバイダーは、フリー スレッドは、UNICODE に対応します。
 
@@ -117,7 +117,7 @@ MSIDXS
 |[Update](../../../ado/reference/ado-api/update-method.md)|いいえ|
 |[UpdateBatch](../../../ado/reference/ado-api/updatebatch-method.md)|いいえ|
 
- 特定の実装の詳細と Microsoft インテックス サービスの機能について、Microsoft OLE DB プロバイダーを参照してください、 [OLE DB プログラマ ガイド](https://msdn.microsoft.com/library/windows/desktop/ms713643.aspx)、または Windows NT Server Web のサービスの Web ページを参照してくださいサイトです。
+ 特定の実装の詳細と Microsoft インデックス サービスの機能について、Microsoft OLE DB プロバイダーを参照してください、 [OLE DB プログラマ ガイド](https://msdn.microsoft.com/library/windows/desktop/ms713643.aspx)、または Windows NT Server Web のサービスの Web ページを参照してくださいサイトです。
 
 ## <a name="see-also"></a>参照
  [CommandType プロパティ (ADO)](../../../ado/reference/ado-api/commandtype-property-ado.md) [ConnectionString プロパティ (ADO)](../../../ado/reference/ado-api/connectionstring-property-ado.md) [Properties コレクション (ADO)](../../../ado/reference/ado-api/properties-collection-ado.md) [Provider プロパティ (ADO)](../../../ado/reference/ado-api/provider-property-ado.md) [RecordSet オブジェクト (ADO)](../../../ado/reference/ado-api/recordset-object-ado.md) [Supports メソッド](../../../ado/reference/ado-api/supports-method.md)

--- a/docs/ado/guide/appendixes/microsoft-ole-db-provider-for-microsoft-indexing-service.md
+++ b/docs/ado/guide/appendixes/microsoft-ole-db-provider-for-microsoft-indexing-service.md
@@ -31,13 +31,13 @@ Microsoft OLE DB Provider for Microsoft インテックス サービスは、フ
  プロバイダーは、フリー スレッドは、UNICODE に対応します。
 
 ## <a name="connection-string-parameters"></a>接続文字列パラメーター
- このプロバイダーに接続するには、設定、**プロバイダー =** への引数、 [ConnectionString](../../../ado/reference/ado-api/connectionstring-property-ado.md)プロパティ。
+ このプロバイダーに接続するには、設定、**Provider =** への引数、 [ConnectionString](../../../ado/reference/ado-api/connectionstring-property-ado.md)プロパティ。
 
 ```
 MSIDXS
 ```
 
- 読み取り、[プロバイダー](../../../ado/reference/ado-api/provider-property-ado.md)プロパティは同様に、この文字列を返します。
+ 読み取り、[Provider](../../../ado/reference/ado-api/provider-property-ado.md)プロパティは同様に、この文字列を返します。
 
 ## <a name="typical-connection-string"></a>一般的な接続文字列
  このプロバイダーの一般的な接続文字列とは。
@@ -50,12 +50,12 @@ MSIDXS
 
 |Keyword|説明|
 |-------------|-----------------|
-|**プロバイダー**|Microsoft インテックス サービス用の OLE DB プロバイダーを指定します。 通常これは、接続文字列で指定された唯一のキーワードです。|
-|**[データ ソース]**|インデックス サービス カタログ名を指定します。 このキーワードが指定されていない場合は、既定のシステム カタログが使用されます。|
-|**[Locale Identifier]**|32 ビットの一意の番号 (1033 など)、ユーザーの言語に関連する設定を指定するを指定します。 このキーワードが指定されていない、既定のシステムのロケール識別子が使用されます。|
+|**Provider**|Microsoft インデックス サービス用の OLE DB プロバイダーを指定します。 通常これは、接続文字列で指定された唯一のキーワードです。|
+|**Data Source**|インデックス サービス カタログ名を指定します。 このキーワードが指定されていない場合は、既定のシステム カタログが使用されます。|
+|**Locale Identifier**|32 ビットの一意の番号 (1033 など)、ユーザーの言語に関連する設定を指定するを指定します。 このキーワードが指定されていない、既定のシステムのロケール識別子が使用されます。|
 
 ## <a name="command-text"></a>コマンド テキスト
- インデックス作成サービスの SQL クエリ構文では、SQL 92 に拡張機能の**選択**ステートメントとその**FROM**と**場所**句。 ADO で使用およびとして操作可能な OLE DB 行セットを使用して、クエリの結果が返されます[Recordset](../../../ado/reference/ado-api/recordset-object-ado.md)オブジェクト。
+ インデックス作成サービスの SQL クエリ構文では、SQL 92 に拡張機能の **SELECT** ステートメントとその **FROM** と **WHERE** 句。 ADO で使用およびとして操作可能な OLE DB 行セットを使用して、クエリの結果が返されます [Recordset](../../../ado/reference/ado-api/recordset-object-ado.md) オブジェクト。
 
  正確な単語や語句を検索したり、ワイルドカード パターンや単語の語幹検索を使用できます。 検索ロジックは、ブール型の決定、重み付け語句は、またはその他の語に近接に基づいて作成できます。 また、「フリー テキスト」一致する語句ではなく、意味のものによって検索することができます。
 
@@ -64,9 +64,9 @@ MSIDXS
  プロバイダーはストアド プロシージャの呼び出しまたは単純なテーブル名を受け付けません (たとえば、 [CommandType](../../../ado/reference/ado-api/commandtype-property-ado.md)プロパティが必ず**adCmdText**)。
 
 ## <a name="recordset-behavior"></a>レコード セットの動作
- 次の表で使用できる機能の一覧、**レコード セット**オブジェクトをこのプロバイダーに開きます。 静的カーソルの種類のみ (**adOpenStatic**) は使用できます。
+ 次の表で使用できる機能の一覧、**Recordset**オブジェクトをこのプロバイダーに開きます。 静的カーソルの種類のみ (**adOpenStatic**) は使用できます。
 
- 詳細については**レコード セット**実行、プロバイダーの構成の動作、[サポート](../../../ado/reference/ado-api/supports-method.md)メソッドを列挙し、[プロパティ](../../../ado/reference/ado-api/properties-collection-ado.md)のコレクション、**Recordset**をプロバイダーに固有の動的なプロパティが存在するかどうかを判断します。
+ 詳細については**Recordset**実行、プロバイダーの構成の動作、[Supports](../../../ado/reference/ado-api/supports-method.md)メソッドを列挙し、[Properties](../../../ado/reference/ado-api/properties-collection-ado.md)のコレクション、**Recordset**をプロバイダーに固有の動的なプロパティが存在するかどうかを判断します。
 
  **標準の ADO レコード セットのプロパティの可用性:**
 
@@ -76,7 +76,7 @@ MSIDXS
 |[AbsolutePosition](../../../ado/reference/ado-api/absoluteposition-property-ado.md)|読み取り/書き込み|
 |[ActiveConnection](../../../ado/reference/ado-api/activeconnection-property-ado.md)|読み取り専用|
 |[BOF](../../../ado/reference/ado-api/bof-eof-properties-ado.md)|読み取り専用|
-|[ブックマーク](../../../ado/reference/ado-api/bookmark-property-ado.md)*|読み取り/書き込み|
+|[Bookmark](../../../ado/reference/ado-api/bookmark-property-ado.md)\*|読み取り/書き込み|
 |[CacheSize](../../../ado/reference/ado-api/cachesize-property-ado.md)|読み取り/書き込み|
 |[CursorLocation](../../../ado/reference/ado-api/cursorlocation-property-ado.md)|always **adUseServer**|
 |[CursorType](../../../ado/reference/ado-api/cursortype-property-ado.md)|always **adOpenStatic**|
@@ -89,9 +89,9 @@ MSIDXS
 |[PageCount](../../../ado/reference/ado-api/pagecount-property-ado.md)|読み取り専用|
 |[PageSize](../../../ado/reference/ado-api/pagesize-property-ado.md)|読み取り/書き込み|
 |[RecordCount](../../../ado/reference/ado-api/recordcount-property-ado.md)|読み取り専用|
-|[ソース](../../../ado/reference/ado-api/source-property-ado-recordset.md)|読み取り/書き込み|
-|[状態](../../../ado/reference/ado-api/state-property-ado.md)|読み取り専用|
-|[ステータス](../../../ado/reference/ado-api/status-property-ado-recordset.md)|読み取り専用|
+|[Source](../../../ado/reference/ado-api/source-property-ado-recordset.md)|読み取り/書き込み|
+|[State](../../../ado/reference/ado-api/state-property-ado.md)|読み取り専用|
+|[Status](../../../ado/reference/ado-api/status-property-ado-recordset.md)|読み取り専用|
 
  \*この機能の順序で上に存在するプロバイダーのブックマークを有効にする必要があります、 **Recordset**です。
 
@@ -100,24 +100,24 @@ MSIDXS
 |方法|使用できるか。|
 |------------|----------------|
 |[AddNew](../../../ado/reference/ado-api/addnew-method-ado.md)|いいえ|
-|[キャンセル](../../../ado/reference/ado-api/cancel-method-ado.md)|はい|
+|[Cancel](../../../ado/reference/ado-api/cancel-method-ado.md)|はい|
 |[CancelBatch](../../../ado/reference/ado-api/cancelbatch-method-ado.md)|いいえ|
-|[ただし](../../../ado/reference/ado-api/cancelupdate-method-ado.md)|いいえ|
-|[複製](../../../ado/reference/ado-api/clone-method-ado.md)|はい|
-|[[閉じる]](../../../ado/reference/ado-api/close-method-ado.md)|はい|
-|[削除](../../../ado/reference/ado-api/delete-method-ado-recordset.md)|いいえ|
+|[CancelUpdate](../../../ado/reference/ado-api/cancelupdate-method-ado.md)|いいえ|
+|[Clone](../../../ado/reference/ado-api/clone-method-ado.md)|はい|
+|[Close](../../../ado/reference/ado-api/close-method-ado.md)|はい|
+|[Delete](../../../ado/reference/ado-api/delete-method-ado-recordset.md)|いいえ|
 |[GetRows](../../../ado/reference/ado-api/getrows-method-ado.md)|はい|
-|[[移動]](../../../ado/reference/ado-api/move-method-ado.md)|はい|
+|[Move](../../../ado/reference/ado-api/move-method-ado.md)|はい|
 |[MoveFirst](../../../ado/reference/ado-api/movefirst-movelast-movenext-and-moveprevious-methods-ado.md)|はい|
 |[NextRecordset](../../../ado/reference/ado-api/nextrecordset-method-ado.md)|はい|
-|[開く](../../../ado/reference/ado-api/open-method-ado-recordset.md)|はい|
-|[クエリを再実行します。](../../../ado/reference/ado-api/requery-method.md)|はい|
-|[再同期](../../../ado/reference/ado-api/resync-method.md)|はい|
-|[サポートしています](../../../ado/reference/ado-api/supports-method.md)|はい|
+|[Open](../../../ado/reference/ado-api/open-method-ado-recordset.md)|はい|
+|[Requery](../../../ado/reference/ado-api/requery-method.md)|はい|
+|[Resync](../../../ado/reference/ado-api/resync-method.md)|はい|
+|[Supports](../../../ado/reference/ado-api/supports-method.md)|はい|
 |[Update](../../../ado/reference/ado-api/update-method.md)|いいえ|
 |[UpdateBatch](../../../ado/reference/ado-api/updatebatch-method.md)|いいえ|
 
  特定の実装の詳細と Microsoft インテックス サービスの機能について、Microsoft OLE DB プロバイダーを参照してください、 [OLE DB プログラマ ガイド](https://msdn.microsoft.com/library/windows/desktop/ms713643.aspx)、または Windows NT Server Web のサービスの Web ページを参照してくださいサイトです。
 
 ## <a name="see-also"></a>参照
- [CommandType プロパティ (ADO)](../../../ado/reference/ado-api/commandtype-property-ado.md) [ConnectionString プロパティ (ADO)](../../../ado/reference/ado-api/connectionstring-property-ado.md) [プロパティのコレクション (ADO)](../../../ado/reference/ado-api/properties-collection-ado.md) [プロバイダー プロパティ (ADO)](../../../ado/reference/ado-api/provider-property-ado.md) [レコード セット オブジェクト (ADO)](../../../ado/reference/ado-api/recordset-object-ado.md) [メソッドをサポートしています](../../../ado/reference/ado-api/supports-method.md)
+ [CommandType プロパティ (ADO)](../../../ado/reference/ado-api/commandtype-property-ado.md) [ConnectionString プロパティ (ADO)](../../../ado/reference/ado-api/connectionstring-property-ado.md) [Properties コレクション (ADO)](../../../ado/reference/ado-api/properties-collection-ado.md) [Provider プロパティ (ADO)](../../../ado/reference/ado-api/provider-property-ado.md) [RecordSet オブジェクト (ADO)](../../../ado/reference/ado-api/recordset-object-ado.md) [Supports メソッド](../../../ado/reference/ado-api/supports-method.md)


### PR DESCRIPTION
Names of keywords, properties and methods should not be translated.