### PR TITLE
Update sys-dm-exec-session-wait-stats-transact-sql.md

### DIFF
--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-exec-session-wait-stats-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-exec-session-wait-stats-transact-sql.md
@@ -29,7 +29,7 @@ ms.lasthandoff: 05/23/2018
 # <a name="sysdmexecsessionwaitstats-transact-sql"></a>sys.dm_exec_session_wait_stats (TRANSACT-SQL)
 [!INCLUDE[tsql-appliesto-ss2016-asdb-xxxx-xxx-md](../../includes/tsql-appliesto-ss2016-asdb-xxxx-xxx-md.md)]
 
-  セッションごとに実行されたスレッドにより検出されたすべての待機に関する情報を返します。 このビューは、パフォーマンスの問題を診断を使用することができます、[!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)]セッションと、特定のクエリとバッチです。  このビューは [sys.dm_os_wait_stats &#40;TRANSACT-SQL&#41; ](../../relational-databases/system-dynamic-management-views/sys-dm-os-wait-stats-transact-sql.md) に集計されたのと同じ情報を返しますが、 **session_id** 番号もあわせて提供します。
+  セッションごとに実行されたスレッドにより検出されたすべての待機に関する情報を返します。 このビューを使用すると、SQL Serverセッション[!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)]のパフォーマンスの問題や特定のクエリやバッチを診断することができます。 このビューは [sys.dm_os_wait_stats &#40;TRANSACT-SQL&#41; ](../../relational-databases/system-dynamic-management-views/sys-dm-os-wait-stats-transact-sql.md) に集計されたものと同じ情報を返しますが、 **session_id** 番号もあわせて提供します。
   
 **適用対象**: [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] ([!INCLUDE[ssSQL15](../../includes/sssql15-md.md)] から [!INCLUDE[ssCurrent](../../includes/sscurrent-md.md)]まで)。  
   

--- a/docs/relational-databases/system-dynamic-management-views/sys-dm-exec-session-wait-stats-transact-sql.md
+++ b/docs/relational-databases/system-dynamic-management-views/sys-dm-exec-session-wait-stats-transact-sql.md
@@ -29,7 +29,7 @@ ms.lasthandoff: 05/23/2018
 # <a name="sysdmexecsessionwaitstats-transact-sql"></a>sys.dm_exec_session_wait_stats (TRANSACT-SQL)
 [!INCLUDE[tsql-appliesto-ss2016-asdb-xxxx-xxx-md](../../includes/tsql-appliesto-ss2016-asdb-xxxx-xxx-md.md)]
 
-  セッションごとに実行されたスレッドにより検出されたすべての待機に関する情報を返します。 このビューは、パフォーマンスの問題を診断を使用することができます、[!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)]セッションと、特定のクエリとバッチです。  このビューは、セッションの集計された同じ情報を返す[sys.dm_os_wait_stats &#40;TRANSACT-SQL&#41; ](../../relational-databases/system-dynamic-management-views/sys-dm-os-wait-stats-transact-sql.md)が、提供、 **session_id**番号もします。  
+  セッションごとに実行されたスレッドにより検出されたすべての待機に関する情報を返します。 このビューは、パフォーマンスの問題を診断を使用することができます、[!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)]セッションと、特定のクエリとバッチです。  このビューは [sys.dm_os_wait_stats &#40;TRANSACT-SQL&#41; ](../../relational-databases/system-dynamic-management-views/sys-dm-os-wait-stats-transact-sql.md) に集計されたのと同じ情報を返しますが、 **session_id** 番号もあわせて提供します。
   
 **適用対象**: [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] ([!INCLUDE[ssSQL15](../../includes/sssql15-md.md)] から [!INCLUDE[ssCurrent](../../includes/sscurrent-md.md)]まで)。  
   


### PR DESCRIPTION
Hi team,

I found a bit of unnatural sentences in Japanese language, and I believe this needs to be fixed. This PR:

- suggests that elaborating a document linguistically in Japanese language.
- is supposed to be addressed as a `Linguistic Suggestion` from my point of view.
- is in regard to https://docs.microsoft.com/ja-jp/sql/relational-databases/system-dynamic-management-views/sys-dm-exec-session-wait-stats-transact-sql.

Best regards,