### PR TITLE
Corrected hour abbreviation to hh

### DIFF
--- a/docs/t-sql/functions/datediff-transact-sql.md
+++ b/docs/t-sql/functions/datediff-transact-sql.md
@@ -69,7 +69,7 @@ DATEDIFF ( datepart , startdate , enddate )
 |**dayofyear**|**dy、y**|  
 |**day**|**dd, d**|  
 |**week**|**wk, ww**|  
-|**hour**|**mm**|  
+|**hour**|**hh**|  
 |**minute**|**mi、n**|  
 |**second**|**ss, s**|  
 |**millisecond**|**ms**|  


### PR DESCRIPTION
Fixed that the abbreviation of "hour" was "mm" to "hh".