### PR TITLE
Fixed Japanese detailed notation of sp_rename.

### DIFF
--- a/docs/relational-databases/tables/rename-columns-database-engine.md
+++ b/docs/relational-databases/tables/rename-columns-database-engine.md
@@ -82,8 +82,8 @@ ms.locfileid: "47745097"
   
 2.  [標準] ツール バーの **[新しいクエリ]** をクリックします。  
   
-3.  次の例では、 `TerritoryID` テーブル内の `Sales.SalesTerritory` 列の名前を `TerrID`に変更します。 次の例をコピーしてクエリ ウィンドウに貼り付け、 **[実行]** をクリックします。  
   
+3.  次の例では、 `Sales.SalesTerritory` テーブル内の `TerritoryID` 列の名前を `TerrID`に変更します。 次の例をコピーしてクエリ ウィンドウに貼り付け、 **[実行]** をクリックします。  
     ```  
     USE AdventureWorks2012;  
     GO  

--- a/docs/relational-databases/tables/rename-tables-database-engine.md
+++ b/docs/relational-databases/tables/rename-tables-database-engine.md
@@ -81,8 +81,8 @@ Azure SQL Data Warehouse または Parallel Data Warehouse でテーブルの名
   
 2.  [標準] ツール バーの **[新しいクエリ]** をクリックします。  
   
-3.  次の例では、 `SalesTerritory` スキーマの `SalesTerr` テーブルの名前を `Sales` に変更します。 次の例をコピーしてクエリ ウィンドウに貼り付け、 **[実行]** をクリックします。  
   
+3.  次の例では、 `Sales` スキーマの `SalesTerritory` テーブルの名前を `SalesTerr` に変更します。 次の例をコピーしてクエリ ウィンドウに貼り付け、 **[実行]** をクリックします。  
     ```  
     USE AdventureWorks2012;   
     GO  


### PR DESCRIPTION
I found a Japanese translation mistake in the following file.
- docs/relational-databases/tables/rename-tables-database-engine.md
- docs/relational-databases/tables/rename-columns-database-engine.md

It was supposed to be like this.

次の例では、 `TerritoryID` テーブル内の `Sales.SalesTerritory` 列の名前を `TerrID`に変更します。
→ The following example renames the column Sales.SalesTerritory in the table TerritoryID to TerrID.

次の例では、 `SalesTerritory` スキーマの `SalesTerr` テーブルの名前を `Sales` に変更します。
→ The following example renames the SalesTerr table to Sales in the SalesTerritory schema.

I would like you to merge it if you consider it and have no problem.

Best regards,