### PR TITLE
The term ”真数" does not mean "Exact Numerics".

### DIFF
--- a/docs/t-sql/data-types/data-types-transact-sql.md
+++ b/docs/t-sql/data-types/data-types-transact-sql.md
@@ -47,8 +47,8 @@ ms.locfileid: "50970433"
   
 |||  
 |-|-|  
-|真数|Unicode 文字列|  
-|概数|バイナリ文字列|  
+|真数型|Unicode 文字列|  
+|概数型|バイナリ文字列|  
 |日付と時刻|その他のデータ型|  
 |文字列||  
   
@@ -59,7 +59,7 @@ ms.locfileid: "50970433"
     > [!NOTE]  
     >  sp_help は、大きな値および **xml** を受け取るデータ型の長さとして -1 を返します。  
   
-### <a name="exact-numerics"></a>真数
+### <a name="exact-numerics"></a>真数型
   
 |||  
 |-|-|  
@@ -69,7 +69,7 @@ ms.locfileid: "50970433"
 |[int](../../t-sql/data-types/int-bigint-smallint-and-tinyint-transact-sql.md)|[tinyint](../../t-sql/data-types/int-bigint-smallint-and-tinyint-transact-sql.md)|  
 |[money](../../t-sql/data-types/money-and-smallmoney-transact-sql.md)||  
   
-### <a name="approximate-numerics"></a>概数
+### <a name="approximate-numerics"></a>概数型
   
 |||  
 |-|-|  


### PR DESCRIPTION
The term ”真数" does not mean "Exact Numerics" meaning, but "真数型" means "Exact Numerics Type" in computer.

The term "真数" used in math and means "antilogarithm" .

The term "概数" means "Approximate Numerics ", but updating to "概数型" (Approximate Numerics Type) for consistency with "真数型".