### PR TITLE
Suggest to fix translations

### DIFF
--- a/docs/t-sql/statements/create-external-table-as-select-transact-sql.md
+++ b/docs/t-sql/statements/create-external-table-as-select-transact-sql.md
@@ -103,7 +103,7 @@ CREATE EXTERNAL TABLE [ [database_name  . [ schema_name ] . ] | schema_name . ] 
   
  例:  
   
- この例では、拒否の 3 つのオプションが相互にやり取りする方法を示します。 たとえば、REJECT_TYPE = percentage、REJECT_VALUE = 30、および REJECT_SAMPLE_VALUE = 100 の場合、次のシナリオが発生する可能性があります。  
+ この例では、REJECT の 3 つのオプションが相互にやり取りする方法を示します。 たとえば、REJECT_TYPE = percentage、REJECT_VALUE = 30、REJECT_SAMPLE_VALUE = 100 の場合、次のようなシナリオとなる可能性があります。  
   
 -   データベースは、最初の 100 行の読み込みを試みます。この場合、失敗が 25、成功が 75 です。  
   

--- a/docs/t-sql/statements/create-external-table-as-select-transact-sql.md
+++ b/docs/t-sql/statements/create-external-table-as-select-transact-sql.md
@@ -103,7 +103,7 @@ CREATE EXTERNAL TABLE [ [database_name  . [ schema_name ] . ] | schema_name . ] 
   
  例:  
   
- この例では、拒否の 3 つのオプションが相互にやり取りする方法を示します。 たとえば場合、REJECT_TYPE 割合、REJECT_VALUE を = = 30、および REJECT_SAMPLE_VALUE、次のシナリオが発生する可能性が 100 を =。  
+ この例では、拒否の 3 つのオプションが相互にやり取りする方法を示します。 たとえば、REJECT_TYPE = percentage、REJECT_VALUE = 30、および REJECT_SAMPLE_VALUE = 100 の場合、次のシナリオが発生する可能性があります。  
   
 -   データベースは、最初の 100 行の読み込みを試みます。この場合、失敗が 25、成功が 75 です。  
   


### PR DESCRIPTION
| [original](https://docs.microsoft.com/en-us/sql/t-sql/statements/create-external-table-as-select-transact-sql?view=azure-sqldw-latest) | before | after |
|-|-|-|
| For example, if REJECT_TYPE = percentage, REJECT_VALUE = 30, and REJECT_SAMPLE_VALUE = 100, the following scenario could occur: | たとえば場合、REJECT_TYPE 割合、REJECT_VALUE を = = 30、および REJECT_SAMPLE_VALUE、次のシナリオが発生する可能性が 100 を =。 | たとえば、REJECT_TYPE = percentage、REJECT_VALUE = 30、および REJECT_SAMPLE_VALUE = 100 の場合、次のシナリオが発生する可能性があります。 |
