### PR TITLE
fix "[SET TEXTSIZE] (&) #40 です。TRANSACT-SQL と #41 です。"→"SET TEXTSIZE …

### DIFF
--- a/docs/t-sql/data-types/ntext-text-and-image-transact-sql.md
+++ b/docs/t-sql/data-types/ntext-text-and-image-transact-sql.md
@@ -53,7 +53,7 @@ ms.locfileid: "56030103"
 |関数|ステートメント|  
 |---|---|
 |[DATALENGTH &#40;Transact-SQL&#41;](../../t-sql/functions/datalength-transact-sql.md)|[READTEXT &#40;Transact-SQL&#41;](../../t-sql/queries/readtext-transact-sql.md)|  
-|[PATINDEX &#40;Transact-SQL&#41;](../../t-sql/functions/patindex-transact-sql.md)|[[SET TEXTSIZE] (&) #40 です。TRANSACT-SQL と #41 です。](../../t-sql/statements/set-textsize-transact-sql.md)|  
+|[PATINDEX &#40;Transact-SQL&#41;](../../t-sql/functions/patindex-transact-sql.md)|[SET TEXTSIZE &#40;Transact-SQL&#41;](../../t-sql/statements/set-textsize-transact-sql.md)|  
 |[SUBSTRING &#40;Transact-SQL&#41;](../../t-sql/functions/substring-transact-sql.md)|[UPDATETEXT &#40;Transact-SQL&#41;](../../t-sql/queries/updatetext-transact-sql.md)|  
 |[TEXTPTR &#40;Transact-SQL&#41;](../../t-sql/functions/text-and-image-functions-textptr-transact-sql.md)|[WRITETEXT &#40;Transact-SQL&#41;](../../t-sql/queries/writetext-transact-sql.md)|  
 |[TEXTVALID &#40;Transact-SQL&#41;](../../t-sql/functions/text-and-image-functions-textvalid-transact-sql.md)||  


### PR DESCRIPTION
…&#40;Transact-SQL&#41;"

https://docs.microsoft.com/ja-jp/sql/t-sql/data-types/ntext-text-and-image-transact-sql?view=sql-server-2017