### PR TITLE
fix "(&) #40 です。TRANSACT-SQL と #41 です。"→"&#40;Transact-SQL&#41;"

### DIFF
--- a/docs/t-sql/language-elements/greater-than-transact-sql.md
+++ b/docs/t-sql/language-elements/greater-than-transact-sql.md
@@ -101,6 +101,6 @@ TRUE
 ## <a name="see-also"></a>参照  
  [IIF &#40;Transact-SQL&#41;](../../t-sql/functions/logical-functions-iif-transact-sql.md)   
  [データ型 &#40;Transact-SQL&#41;](../../t-sql/data-types/data-types-transact-sql.md)   
- [演算子 (&) #40 です。TRANSACT-SQL と #41 です。](../../t-sql/language-elements/operators-transact-sql.md)  
+ [演算子 &#40;Transact-SQL&#41;](../../t-sql/language-elements/operators-transact-sql.md)  
   
   


### PR DESCRIPTION
https://docs.microsoft.com/ja-jp/sql/t-sql/language-elements/greater-than-transact-sql?view=sql-server-2017