### PR TITLE
Suggest to fix case

### DIFF
--- a/docs/advanced-analytics/index.yml
+++ b/docs/advanced-analytics/index.yml
@@ -54,11 +54,11 @@ sections:
         style: unordered
         items:
           - html: '<a href="r/ref-r-revoscaler">R の RevoScaleR</a>:R タスクの分散および並列処理: データ変換、探索、視覚化、統計および予測分析。'
-          - html: '<a href="r/ref-r-microsoftml">R</a>の microsoft Ml: Microsoft AI アルゴリズムに基づく Functions (r に適合)'
-          - html: '<a href="r/ref-r-olapr">R の Olapr</a>:OLAP キューブからデータをインポートします'
+          - html: '<a href="r/ref-r-microsoftml">R の MicrosoftML</a>: Microsoft AI アルゴリズムに基づく関数 (R に適合)'
+          - html: '<a href="r/ref-r-olapr">R の olapR</a>:OLAP キューブからデータをインポートします'
           - html: '<a href="r/ref-r-sqlrutils">R の sqlRUtils</a>:R と T-sql をカプセル化するためのヘルパー関数'
-          - html: '<a href="python/ref-py-revoscalepy">Python での revoscalepy</a>:Python タスクの分散および並列処理: データ変換、探索、視覚化、統計および予測分析'
-          - html: '<a href="python/ref-py-microsoftml">Python での microsoft ml</a>:Python に適合する Microsoft AI アルゴリズムに基づく関数'
+          - html: '<a href="python/ref-py-revoscalepy">Python の revoscalepy</a>:Python タスクの分散および並列処理: データ変換、探索、視覚化、統計および予測分析'
+          - html: '<a href="python/ref-py-microsoftml">Python の microsoftml</a>:Python に適合する Microsoft AI アルゴリズムに基づく関数'
   - title: その他の Machine Learning テクノロジ
     items:
       - type: list


### PR DESCRIPTION
* 'a' end tag of 'MicrosoftML in R'
* case of 'MicrosoftML', and it is one word
* translation of 'functions' : emphasis that it isn't 'Azure Functions'
* case of 'R'
* case of 'olapR'
* translation of 'in Python' : 'での' -> 'の', match with translation of 'in R' above
* 'microsoftml' is one word
