### PR TITLE
fixed inappropriate japanese "付録 b:。ODBC の状態遷移テーブルします。"→"付録 B:ODBC の状…

### DIFF
--- a/docs/odbc/reference/develop-app/closing-the-cursor.md
+++ b/docs/odbc/reference/develop-app/closing-the-cursor.md
@@ -27,7 +27,7 @@ ms.locfileid: "68036546"
 SQLCloseCursor(hstmt);  
 ```  
   
- アプリケーションが、カーソルを閉じるまで、別の SQL ステートメントの実行など、他のほとんどの操作、カーソルを開いた、ステートメントを使用できません。 カーソルが開いているときに呼び出すことができる関数の完全な一覧については、[付録 B:ODBC の状態遷移テーブル](../../../odbc/reference/appendixes/appendix-b-odbc-state-transition-tables.md)を参照してください。  
+ アプリケーションがカーソルを閉じるまで、別の SQL ステートメントの実行など、カーソルを開かれているステートメントは他のほとんどの操作に使用できません。 カーソルが開いているときに呼び出すことができる関数の完全な一覧については、[付録 B:ODBC の状態遷移テーブル](../../../odbc/reference/appendixes/appendix-b-odbc-state-transition-tables.md) を参照してください。    
   
 > [!NOTE]  
 >  カーソルを閉じるには、アプリケーションを呼び出す必要があります**SQLCloseCursor**ではなく、 **SQLCancel**します。  

--- a/docs/odbc/reference/develop-app/closing-the-cursor.md
+++ b/docs/odbc/reference/develop-app/closing-the-cursor.md
@@ -27,7 +27,7 @@ ms.locfileid: "68036546"
 SQLCloseCursor(hstmt);  
 ```  
   
- アプリケーションが、カーソルを閉じるまで、別の SQL ステートメントの実行など、他のほとんどの操作、カーソルを開いた、ステートメントを使用できません。 カーソルが開いているときに呼び出すことができる関数の完全な一覧を参照してください[付録 b:。ODBC の状態遷移テーブル](../../../odbc/reference/appendixes/appendix-b-odbc-state-transition-tables.md)します。  
+ アプリケーションが、カーソルを閉じるまで、別の SQL ステートメントの実行など、他のほとんどの操作、カーソルを開いた、ステートメントを使用できません。 カーソルが開いているときに呼び出すことができる関数の完全な一覧については、[付録 B:ODBC の状態遷移テーブル](../../../odbc/reference/appendixes/appendix-b-odbc-state-transition-tables.md)を参照してください。  
   
 > [!NOTE]  
 >  カーソルを閉じるには、アプリケーションを呼び出す必要があります**SQLCloseCursor**ではなく、 **SQLCancel**します。  


### PR DESCRIPTION
…態遷移テーブル"

https://docs.microsoft.com/ja-jp/sql/odbc/reference/develop-app/closing-the-cursor?view=sql-server-2017