### PR TITLE
fix "&#40; です。TRANSACT-SQL と &#41; です。"→"&#40;Transact-SQL&#41;"

### DIFF
--- a/docs/relational-databases/system-tables/mslogreader-agents-transact-sql.md
+++ b/docs/relational-databases/system-tables/mslogreader-agents-transact-sql.md
@@ -47,7 +47,7 @@ ms.locfileid: "67907300"
 |**job_password**|**nvarchar(524)**||  
   
 ## <a name="see-also"></a>関連項目  
- [レプリケーション テーブル &#40; です。TRANSACT-SQL と &#41; です。](../../relational-databases/system-tables/replication-tables-transact-sql.md)   
+ [レプリケーション テーブル &#40;Transact-SQL&#41;](../../relational-databases/system-tables/replication-tables-transact-sql.md)   
  [レプリケーション ビュー &#40;Transact-SQL&#41;](../../relational-databases/system-views/replication-views-transact-sql.md)  
   
   


### PR DESCRIPTION
https://docs.microsoft.com/ja-jp/sql/relational-databases/system-tables/mslogreader-agents-transact-sql?view=sql-server-2017