### PR TITLE
fix "&#40; です。TRANSACT-SQL と &#41; です。"→"&#40;Transact-SQL&#41;"

### DIFF
--- a/docs/リレーショナルデータベース/システムテーブル/ihpublishercolumnconstraints-transact-sql.md
+++ b/docs/リレーショナルデータベース/システムテーブル/ihpublishercolumnconstraints-transact-sql.md
@@ -39,7 +39,7 @@ ms.locfileid: "67990286"
   
 ## <a name="see-also"></a>関連項目  
  [異種データベース レプリケーション](../../relational-databases/replication/non-sql/heterogeneous-database-replication.md)   
- [レプリケーション テーブル &#40; です。TRANSACT-SQL と &#41; です。](../../relational-databases/system-tables/replication-tables-transact-sql.md)   
+ [レプリケーション テーブル &#40;Transact-SQL&#41;](../../relational-databases/system-tables/replication-tables-transact-sql.md)   
  [レプリケーション ビュー &#40;Transact-SQL&#41;](../../relational-databases/system-views/replication-views-transact-sql.md)  
   
   


### PR DESCRIPTION
https://docs.microsoft.com/ja-jp/sql/relational-databases/system-tables/ihpublishercolumnconstraints-transact-sql?view=sql-server-2017