### PR TITLE
Update hardware-and-software-requirements-for-installing-sql-server.md

### DIFF
--- a/docs/sql-server/install/hardware-and-software-requirements-for-installing-sql-server.md
+++ b/docs/sql-server/install/hardware-and-software-requirements-for-installing-sql-server.md
@@ -266,7 +266,7 @@ Server Core への SQL Server のインストールの詳細については、�
   
   
   
-##  <a name="DC_support"></a> FAT32 ファイル システムのコンピューターへの [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] のインストール  
+##  <a name="DC_support"></a> ドメイン コントローラーへの [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] のインストール  
  セキュリティ上の理由から、ドメイン コントローラーには [!INCLUDE[ssCurrent](../../includes/ssnoversion-md.md)] をインストールしないことをお勧めします。 [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] のセットアップ時にインストールが中止されることはありませんが、次の制限事項が適用されます。  
   
 -   ローカル サービス アカウントを使用して、ドメイン コントローラー上で [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] サービスを実行することはできません。    
@@ -274,8 +274,10 @@ Server Core への SQL Server のインストールの詳細については、�
 -   コンピューターに [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] をインストールした後で、そのコンピューターをドメイン コントローラーからドメイン メンバーに変更することはできません。 ホスト コンピューターをドメイン メンバーに変更する前に、 [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] をアンインストールする必要があります。   
 -   [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] フェールオーバー クラスター インスタンスは、クラスター ノードがドメイン コントローラーの場合はサポートされません。   
 - [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] は、読み取り専用ドメイン コントローラーではサポートされません。 [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] セットアップでは、読み取り専用ドメイン コントローラーにセキュリティ グループを作成したり [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] サービス アカウントを準備したりすることはできません。 この場合、セットアップは失敗します。 
+  *この制限はドメイン メンバー ノードへのインストールに対しても適用されます。
 - [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] フェールオーバー クラスター インスタンスは、読み取り専用ドメイン コントローラーのみにアクセスできる環境ではサポートされません。 
-  
+  *この制限はドメイン メンバー ノードへのインストールに対しても適用されます。
+
 ## <a name="see-also"></a>参照  
  [SQL Server のインストール計画](../../sql-server/install/planning-a-sql-server-installation.md)   
  [SQL Server インストールにおけるセキュリティの考慮事項](../../sql-server/install/security-considerations-for-a-sql-server-installation.md)   


### PR DESCRIPTION
LINE 269：
US Docs では「Installing SQL Server on a Domain Controller」と書かれているため。

LINE 277, 279：
この項に記載されていると、ドメイン コントローラーに SQL Server をインストールする場合のみとお客様が受け取ってしまうため。
実際にお客様から、ドメイン コントローラーだけの制限と受け取ってしまったと修正のフィードバックを頂いています。