### PR TITLE
fix "&#40; です。TRANSACT-SQL と &#41; です。"→"&#40;Transact-SQL&#41;"

### DIFF
--- a/docs/relational-databases/system-tables/mspub-identity-range-transact-sql.md
+++ b/docs/relational-databases/system-tables/mspub-identity-range-transact-sql.md
@@ -39,7 +39,7 @@ ms.locfileid: "68032602"
 |**last_seed**|**bigint**|現在の範囲の下限値です。|  
   
 ## <a name="see-also"></a>関連項目  
- [レプリケーション テーブル &#40; です。TRANSACT-SQL と &#41; です。](../../relational-databases/system-tables/replication-tables-transact-sql.md)   
+ [レプリケーション テーブル &#40;Transact-SQL&#41;](../../relational-databases/system-tables/replication-tables-transact-sql.md)   
  [レプリケーション ビュー &#40;Transact-SQL&#41;](../../relational-databases/system-views/replication-views-transact-sql.md)  
   
   


### PR DESCRIPTION
https://docs.microsoft.com/ja-jp/sql/relational-databases/system-tables/mspub-identity-range-transact-sql?view=sql-server-2017