### PR TITLE
Fix and improve ROWVERSION

### DIFF
--- a/docs/t-sql/data-types/rowversion-transact-sql.md
+++ b/docs/t-sql/data-types/rowversion-transact-sql.md
@@ -36,40 +36,40 @@ ms.locfileid: "68000582"
 # <a name="rowversion-transact-sql"></a>rowversion (Transact-SQL)
 [!INCLUDE[tsql-appliesto-ss2008-asdb-xxxx-xxx-md](../../includes/tsql-appliesto-ss2008-asdb-xxxx-xxx-md.md)]
 
-データベース内で自動的に生成された一意の 2 進数を公開するデータ型です。 **rowversion** は、通常、テーブルの行のバージョンを記録するためのメカニズムとして使用します。 ストレージ サイズは 8 バイトです。 **Rowversion** データ型は数値を加算していくだけであり、日付や時刻では保持されません。 日付または時刻を記録するには、使用、 **datetime2** データ型。
+自動的に生成された、データベース内で一意の 2 進数を公開するデータ型です。 **rowversion** は、通常、テーブルの行のバージョンを記録するためのメカニズムとして使用します。 ストレージ サイズは 8 バイトです。 **rowversion** データ型は数値を加算していくだけであり、日付や時刻では保持されません。 日付または時刻を記録するには、 **datetime2** データ型を使用してください。
   
 ## <a name="remarks"></a>Remarks  
-各データベースを含むテーブルで実行される update 操作または挿入ごとにインクリメントされるカウンターには、 **rowversion** 、データベース内の列です。 このカウンターは、データベース rowversion です。 これにより、クロックへの関連付けが可能な実際の時間ではなく、データベース内の相対時間が追跡されます。 テーブルには、1 つだけ保持できます **rowversion** 列です。 たびにを持つ行、 **rowversion** で増加したデータベース rowversion 値が挿入される、列が変更または挿入、 **rowversion** 列です。 このため、 **rowversion** 列、不適切なキーとして、特に主キー。 行を更新すると rowversion 値が変わるので、キーの値も変わります。 列が主キー内にある場合、以前のキーの値は無効になり、この以前の値を参照する外部キーも無効になります。 動的カーソルでテーブルを参照する場合、すべての更新操作はカーソル上の行の位置を変更します。 列がインデックス キーの場合は、データ行に対するすべての更新によって、インデックスの更新も生成されます。  行の値が変更されない場合でも、**rowversion** 値は、update ステートメントによって増分されます (たとえば、列の値が 5 のときに、update ステートメントによって値が 5 に設定された場合、この操作は値の変更がないにもかかわらず更新とみなされ、**rowversion** は増分されます)。
+データベース毎にカウンターを保持し、データベースの中の **rowversion** 列を含むテーブルに対して実行される挿入または更新操作の度にインクリメントされます。 このカウンターは、データベース rowversion です。 これにより、クロックへの関連付けが可能な実際の時間ではなく、データベース内の相対時間が追跡されます。 テーブルには、1 つだけ **rowversion** 列を保持できます。 **rowversion** 列を持つ行が変更または挿入されるたびに、増加したデータベース rowversion 値が **rowversion** 列に挿入されます。 このため、 **rowversion** 列は、キーとして、特に主キーとして不適切です。 行を更新すると rowversion 値が変わるので、キーの値も変わります。 列が主キー内にある場合、以前のキーの値は無効になり、この以前の値を参照する外部キーも無効になります。 動的カーソルでテーブルを参照する場合、すべての更新操作はカーソル上の行の位置を変更します。 列がインデックス キーの場合は、データ行に対するすべての更新によって、インデックスの更新も生成されます。 行の値が変更されない場合でも、**rowversion** 値は、update ステートメントによって増分されます (たとえば、列の値が 5 のときに、update ステートメントによって値が 5 に設定された場合、この操作は値の変更がないにもかかわらず更新とみなされ、**rowversion** は増分されます)。
   
-**タイムスタンプ** のシノニムには、**rowversion** データを入力し、動作が適用のデータ型のシノニム。 DDL ステートメントでは、次のように使用します。 **rowversion** の代わりに **タイムスタンプ** 可能な限りです。 詳しくは、「[データ型のシノニム &#40;Transact-SQL&#41;](../../t-sql/data-types/data-type-synonyms-transact-sql.md)」をご覧ください。
+**timestamp** は、**rowversion** データ型のシノニムであり、データ型のシノニムの動作が適用されます。 DDL ステートメントでは、可能な限り **timestamp** の代わりに **rowversion** を使用してください。 詳しくは、「[データ型のシノニム &#40;Transact-SQL&#41;](../../t-sql/data-types/data-type-synonyms-transact-sql.md)」をご覧ください。
   
 [!INCLUDE[tsql](../../includes/tsql-md.md)] の **timestamp** データ型は、ISO 標準に定義されている **timestamp** データ型とは異なります。
   
 > [!NOTE]  
->  **タイムスタンプ** 構文は非推奨とされます。 [!INCLUDE[ssNoteDepFutureAvoid](../../includes/ssnotedepfutureavoid-md.md)]  
+>  **timestamp** 構文は非推奨とされます。 [!INCLUDE[ssNoteDepFutureAvoid](../../includes/ssnotedepfutureavoid-md.md)]  
   
-CREATE TABLE または ALTER TABLE ステートメントでは、列名を指定する必要はありません、 **タイムスタンプ** などのデータ型します。
+CREATE TABLE または ALTER TABLE ステートメントでは、 **timestamp** データ型の列名を指定する必要はありません。次に例を示します。
   
 ```sql
 CREATE TABLE ExampleTable (PriKey int PRIMARY KEY, timestamp);  
 ```  
   
-列名を指定しない場合、 [!INCLUDE[ssDEnoversion](../../includes/ssdenoversion-md.md)] 生成、 **タイムスタンプ** 列の名前。 ただし、、 **rowversion** シノニムがこの動作に従っていません。 使用すると **rowversio**n, 、たとえば、列名を指定する必要があります。
+列名を指定しない場合、 [!INCLUDE[ssDEnoversion](../../includes/ssdenoversion-md.md)] が **timestamp** 列名を生成します。 ただし、 **rowversion** シノニムはこの動作に従っていません。 **rowversion** を使用するときは、列名を指定する必要があります。次に例を示します。
   
 ```sql
 CREATE TABLE ExampleTable2 (PriKey int PRIMARY KEY, VerCol rowversion) ;  
 ```  
   
 > [!NOTE]  
->  重複して **rowversion** を SELECT INTO ステートメントを使用して値を生成することができます、 **rowversion** 列が SELECT リストです。 使用しないで **rowversion** をこのようにします。  
+>  **rowversion** 列が SELECT リストに含まれる SELECT INTO ステートメントを使用すると、重複した **rowversion** の値を生成することができます。 このように **rowversion** を使うことはお勧めしません。  
   
-Null 値非許容 **rowversion** 列と同じ意味、 **binary (8)** 列です。 Null 値を許容 **rowversion** 列と同じ意味、 **varbinary (8)** 列です。
+Null 値非許容の **rowversion** 列は、 **binary(8)** 列と同じ意味です。 Null 値許容の **rowversion** 列は、 **varbinary(8)** 列と同じ意味です。
   
 行の **rowversion** 列を使用して、最後の読み取り以降、その行に対して update ステートメントが実行されているかどうかを簡単に判断できます。 行に対して update ステートメントが実行されていれば、rowversion 値は更新されています。 行に対して update ステートメントが実行されていなければ、rowversion 値は前回の読み取り時と同じです。 データベースの現在の rowversion 値を返すには、[@@DBTS](../../t-sql/functions/dbts-transact-sql.md) を使用します。
   
-追加することができます、 **rowversion** 列を複数のユーザーが同時に行を更新するときに、データベースの整合性を維持するためにテーブルです。 テーブルに対するクエリを再度実行せずに、行数や更新された行を把握する必要がある場合もあります。
+複数のユーザーが同時に行を更新するときに、データベースの整合性を維持するために、 **rowversion** 列をテーブルに追加することができます。 テーブルに対するクエリを再度実行せずに、行数や更新された行を把握する必要がある場合もあります。
   
-たとえば、`MyTest` という名前のテーブルを作成するとします。 以下を実行して、テーブル内のデータを設定する [!INCLUDE[tsql](../../includes/tsql-md.md)]ステートメントです。
+たとえば、`MyTest` という名前のテーブルを作成するとします。 以下の [!INCLUDE[tsql](../../includes/tsql-md.md)]ステートメントを実行して、テーブル内のデータを設定します。
   
 ```sql
 CREATE TABLE MyTest (myKey int PRIMARY KEY  
@@ -99,11 +99,11 @@ IF (SELECT COUNT(*) FROM @t) = 0
     END;  
 ```  
   
-`myRv` は、その行の前回の読み取り時間を示す、行の **rowversion** 列の値です。 実際、この値を置き換える必要があります **rowversion** 値。 実際の例 **rowversion** 値は、0x00000000000007d3 などになります。
+`myRv` は、その行の前回の読み取り時間を示す、行の **rowversion** 列の値です。 この値を実際の **rowversion** 値に置き換える必要があります。 実際の **rowversion** 値の例は、0x00000000000007d3 などになります。
   
 また、サンプル [!INCLUDE[tsql](../../includes/tsql-md.md)] ステートメントをトランザクションに置くことができます。 トランザクションの範囲内で `@t` 変数に対してクエリを実行すると、`MyTest` テーブルに対するクエリを再度実行しなくても、テーブルの更新済みの `myKey` 列を取得できます。
   
-同じ例を次に示しますを使用して、 **タイムスタンプ** 構文。
+**timestamp** 構文を使用した同じ例を次に示します。
   
 ```sql
 CREATE TABLE MyTest2 (myKey int PRIMARY KEY  


### PR DESCRIPTION
- 'within a database (データベース内で)' describes 'unique (一意の)'

|original|before|after|
|-|-|-|
|that exposes automatically generated, unique binary numbers within a database|データベース内で自動的に生成された一意の 2 進数を公開する|自動的に生成された、データベース内で一意の 2 進数を公開する|

- rowversion is recommended.

|original|before|after|
|-|-|-|
|use rowversion instead of timestamp wherever possible. |次のように使用します。**rowversion** の代わりに **タイムスタンプ** 可能な限りです。|可能な限り **timestamp** の代わりに **rowversion** を使用してください。|

- 'actual (実際)' describes 'rowversion value'.

|original|before|after|
|-|-|-|
|This value must be replaced by the actual rowversion value.|実際、この値を置き換える必要があります **rowversion** 値。|この値を実際の **rowversion** 値に置き換える必要があります。|