### PR TITLE
Fixd "&#40; です。TRANSACT-SQL と &#41; です。"→"&#40;Transact-SQL&#41;"

### DIFF
--- a/docs/relational-databases/system-tables/mslogreader-history-transact-sql.md
+++ b/docs/relational-databases/system-tables/mslogreader-history-transact-sql.md
@@ -49,7 +49,7 @@ ms.locfileid: "67907296"
 |**updateable_row**|**bit**|設定**1**履歴行を上書きできる場合。|  
   
 ## <a name="see-also"></a>関連項目  
- [レプリケーション テーブル &#40; です。TRANSACT-SQL と &#41; です。](../../relational-databases/system-tables/replication-tables-transact-sql.md)   
+ [レプリケーション テーブル &#40;Transact-SQL&#41;](../../relational-databases/system-tables/replication-tables-transact-sql.md)   
  [レプリケーション ビュー &#40;Transact-SQL&#41;](../../relational-databases/system-views/replication-views-transact-sql.md)  
   
   


### PR DESCRIPTION
https://docs.microsoft.com/ja-jp/sql/relational-databases/system-tables/mslogreader-history-transact-sql?view=sql-server-2017