### PR TITLE
Typo "**@publication=**"→"**\@publication=**"

### DIFF
--- a/docs/relational-databases/system-stored-procedures/sp-validatemergepublication-transact-sql.md
+++ b/docs/relational-databases/system-stored-procedures/sp-validatemergepublication-transact-sql.md
@@ -38,7 +38,7 @@ sp_validatemergepublication [@publication=] 'publication'
 ```  
   
 ## <a name="arguments"></a>引数  
- [ **@publication=** ] **'***publication***'**  
+ [**\@publication=**] **'***publication***'** 
  パブリケーションの名前です。 *パブリケーション* は **sysname** 、既定値はありません。  
   
 `[ @level = ] level` 実行する検証の種類です。 *レベル*は**tinyint**、既定値はありません。 レベルには次のいずれかの値を指定できます。  


### PR DESCRIPTION
bold with escape characters

https://docs.microsoft.com/ja-jp/sql/relational-databases/system-stored-procedures/sp-validatemergepublication-transact-sql?view=sql-server-2017
