### PR TITLE
Fixed "&#40; です。TRANSACT-SQL と &#41; です。"→"&#40;Transact-SQL&#41;"

### DIFF
--- a/docs/relational-databases/system-tables/msmerge-errorlineage-transact-sql.md
+++ b/docs/relational-databases/system-tables/msmerge-errorlineage-transact-sql.md
@@ -36,7 +36,7 @@ ms.locfileid: "68044760"
 |**lineage**|**varbinary(501)**|履歴リストがサブスクライバーとパブリッシャーの更新プログラムに行った行を格納します。 検出および競合の状態を解決するために使用します。|  
   
 ## <a name="see-also"></a>関連項目  
- [レプリケーション テーブル &#40; です。TRANSACT-SQL と &#41; です。](../../relational-databases/system-tables/replication-tables-transact-sql.md)   
+ [レプリケーション テーブル &#40;Transact-SQL&#41;](../../relational-databases/system-tables/replication-tables-transact-sql.md)   
  [レプリケーション ビュー &#40;Transact-SQL&#41;](../../relational-databases/system-views/replication-views-transact-sql.md)  
   
   


### PR DESCRIPTION
https://docs.microsoft.com/ja-jp/sql/relational-databases/system-tables/msmerge-errorlineage-transact-sql?view=sql-server-ver15

提案を送信するための役立つ情報:
1.[ローカライズ スタイル ガイドのクイック スタート](https://docs.microsoft.com/globalization/localization/styleguides) に移動して、Microsoft スタイル ガイドの **最も重要なルール上位 10 個** をご確認ください。
2.[Microsoft ランゲージ ポータル](https://www.microsoft.com/language) に移動して、Microsoft 製品間での **標準化された用語の翻訳** をご確認ください。
