### PR TITLE
Unify translations of "True" and "False"

### DIFF
--- a/docs/connect/ado-net/appcontext-switches.md
+++ b/docs/connect/ado-net/appcontext-switches.md
@@ -61,7 +61,7 @@ AppContext.SetSwitch("Switch.Microsoft.Data.SqlClient.UseManagedNetworkingOnWind
 |TransparentNetworkIPResolution|MultiSubnetFailover|動作|
 |--------|--------|--------|
 |True|True|1|
-|正しい|誤り|0|
+|True|False|0|
 |False|True|1|
 |False|False|2|
 

--- a/docs/connect/oledb/features/using-transparent-network-ip-resolution.md
+++ b/docs/connect/oledb/features/using-transparent-network-ip-resolution.md
@@ -30,7 +30,7 @@ ms.locfileid: "86006809"
 |TransparentNetworkIPResolution|MultiSubnetFailover|動作|
 |--------|--------|--------|
 |True|True|1|
-|正しい|誤り|0|
+|True|False|0|
 |False|True|1|
 |False|False|2|
 


### PR DESCRIPTION
## original

1. True / False

## before

1. True / False
1. 正しい / 誤り

## after

1. True / False